### PR TITLE
fix: update js-yaml to patched 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1932,9 +1932,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "homepage": "https://github.com/Travelport-Czech/valid-objects-ts#readme",
   "overrides": {
-    "js-yaml": "3.15.0",
+    "js-yaml": "3.15.1",
     "minimatch": "3.1.4",
     "mocha": {
       "debug": "3.2.7",


### PR DESCRIPTION
Closes #34

Follow-up to #32 and #33 for [Dependabot alert #91](https://github.com/Travelport-Czech/valid-objects-ts/security/dependabot/91), which tracks [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj).

## Summary

- update the `js-yaml` override from `3.15.0` to the first patched 3.x release, `3.15.1`
- regenerate only the matching `package-lock.json` entry
- keep parent dependencies, package version, and CI workflows unchanged

Both transitive development paths resolve to the single patched instance:

- `mocha@6.2.3` → `js-yaml@3.15.1`
- `tslint@5.15.0` → `js-yaml@3.15.1`

## Validation

- Node.js 22.23.2 / npm 10.9.8: `npm ci`, lint, 26 tests, build, and `npm audit --audit-level=high`
- Node.js 24.18.0 / npm 10.9.8: `npm ci`, lint, 26 tests, build, and `npm audit --audit-level=high`
- both audits report 0 vulnerabilities
- `git diff --check`
- `npm ls js-yaml --all --package-lock-only`